### PR TITLE
Support for sharedKey input from file

### DIFF
--- a/lib/logstash/outputs/oms.rb
+++ b/lib/logstash/outputs/oms.rb
@@ -12,114 +12,124 @@ require 'time'
 require 'uri'
 
 # An example output that does nothing.
-class LogStash::Outputs::Example < LogStash::Outputs::Base
+class LogStash::Outputs::OMS < LogStash::Outputs::Base
   config_name "oms"
 
   # The OMS Customer ID to use
   config :workspaceID, :validate => :string, :required => :true
 
   # The OMS Shared Key to use
-  config :sharedKey, :validate => :string, :required => :true
+  config :sharedKey, :validate => :string
+
+  # OMS credentials file
+  config :oms_creds_file, :validate => :string
 
   # The OMS Log Type to use
   config :logType, :required => :true
 
   public
   def register
-  end # def register
+    if (@oms_creds_file and @sharedKey)
+      raise(LogStash::ConfigurationError, "Only one of :sharedKey, :oms_creds_file may be set at a time.")
+    end
+
+    @sharedKey = File.read(@oms_creds_file).strip if @oms_creds_file
+  end
 
   public
+
   def receive(event)
     post_data(event)
     return "Event received"
-  end # def event
+  end
 
-    def build_signature(date, contentLength)
-      method = 'POST'
-      contentType = 'application/json'
-      resource = '/api/logs'
+  def build_signature(date, contentLength)
+    method = 'POST'
+    contentType = 'application/json'
+    resource = '/api/logs'
 
-      xHeaders = "x-ms-date:#{date}"
-      stringToHash = "#{method}\n#{contentLength}\n#{contentType}\n#{xHeaders}\n#{resource}"
+    xHeaders = "x-ms-date:#{date}"
+    stringToHash = "#{method}\n#{contentLength}\n#{contentType}\n#{xHeaders}\n#{resource}"
 
-      key = Base64.decode64(sharedKey)
-      hash = Base64.encode64(OpenSSL::HMAC.digest('sha256', key, stringToHash)).strip
-      signature = "SharedKey #{workspaceID}:#{hash}"
+    key = Base64.decode64(sharedKey)
+    hash = Base64.encode64(OpenSSL::HMAC.digest('sha256', key, stringToHash)).strip
+    signature = "SharedKey #{workspaceID}:#{hash}"
 
-      return signature
-    end # build_signature 
+    return signature
+  end # build_signature
 
-    def post_data(records)
-      msg = JSON.dump(records)
+  def post_data(records)
+    msg = JSON.dump(records)
 
-      date = Time.now.utc.httpdate()
-      contentLength = msg.bytesize
-      signature = build_signature(date, contentLength)
+    date = Time.now.utc.httpdate()
+    contentLength = msg.bytesize
+    signature = build_signature(date, contentLength)
 
-      headers = {}
-      
-      headers[CaseSensitiveString.new("Authorization")] = signature
-      headers[CaseSensitiveString.new("Log-Type")] = logType
-      headers[CaseSensitiveString.new("x-ms-date")] = date 
-      headers["Content-Type"] = 'application/json'
-      headers["Content-Length"] = contentLength.to_s
+    headers = {}
 
-      req = Net::HTTP::Post.new("https://" + workspaceID + ".ods.opinsights.azure.com/api/logs?api-version=2016-04-01", headers)
-      req.body = msg
- 
-	http = create_secure_http( URI.parse("https://" + workspaceID + ".ods.opinsights.azure.com/api/logs?api-version=2016-04-01") , "") 
-      start_request(req, http)
+    headers[CaseSensitiveString.new("Authorization")] = signature
+    headers[CaseSensitiveString.new("Log-Type")] = logType
+    headers[CaseSensitiveString.new("x-ms-date")] = date
+    headers["Content-Type"] = 'application/json'
+    headers["Content-Length"] = contentLength.to_s
 
-      return contentLength
-    end # post_data 
+    req = Net::HTTP::Post.new("https://" + workspaceID + ".ods.opinsights.azure.com/api/logs?api-version=2016-04-01", headers)
+    req.body = msg
 
-    def start_request(req, secure_http, ignore404 = false)
-        # Tries to send the passed in request
-        # Raises an exception if the request fails.
-        # This exception should only be caught by the fluentd engine so that it retries sending this 
-        begin
-          res = nil
-          res = secure_http.start { |http|  http.request(req) }
-	rescue => e
-		@logger.error("Error in section 1  #{e.message}")
-        else
-	  if res.nil?
-		@logger.error("Failed to request method")
-	  end
+    http = create_secure_http( URI.parse("https://" + workspaceID + ".ods.opinsights.azure.com/api/logs?api-version=2016-04-01") , "")
+    start_request(req, http)
 
-	  if res.is_a?(Net::HTTPSuccess)
-            return res.body
-          end
+    return contentLength
+  end # post_data
 
-          if ignore404 and res.code == "404"
-            return ''
-          end
+  def start_request(req, secure_http, ignore404 = false)
+      # Tries to send the passed in request
+      # Raises an exception if the request fails.
+      # This exception should only be caught by the fluentd engine so that it retries sending this
+    begin
+        res = nil
+        res = secure_http.start { |http|  http.request(req) }
+	  rescue => e
+  		@logger.error("Error in section 1  #{e.message}")
+    else
 
-          if res.code != "200"
-            # Retry all failure error codes...
-            res_summary = "(class=#{res.class.name}; code=#{res.code}; message=#{res.message}; body=#{res.body};)"
-            @logger.error("Failed #{res_summary}")
-  
-	end
+      if res.nil?
+  		    @logger.error("Failed to request method")
+  	  end
 
-        end # end begin
-      end # end start_request
+  	  if res.is_a?(Net::HTTPSuccess)
+        return res.body
+      end
 
-      # create an HTTP object which uses HTTPS
-      def create_secure_http(uri, proxy={})
-        if proxy.empty?
-          http = Net::HTTP.new( uri.host, uri.port )
-        else
-          http = Net::HTTP.new( uri.host, uri.port,
-                                proxy[:addr], proxy[:port], proxy[:user], proxy[:pass])
-        end
-        http.use_ssl = true
-        http.verify_mode = OpenSSL::SSL::VERIFY_NONE
-        http.open_timeout = 30
-        return http
-      end # create_secure_http
+      if ignore404 and res.code == "404"
+        return ''
+      end
 
-end # class LogStash::Outputs::Example
+      if res.code != "200"
+        # Retry all failure error codes...
+        res_summary = "(class=#{res.class.name}; code=#{res.code}; message=#{res.message}; body=#{res.body};)"
+        @logger.error("Failed #{res_summary}")
+      end
+
+    end # end begin
+  end # end start_request
+
+  # create an HTTP object which uses HTTPS
+  def create_secure_http(uri, proxy={})
+    if proxy.empty?
+      http = Net::HTTP.new( uri.host, uri.port )
+    else
+      http = Net::HTTP.new( uri.host, uri.port,
+                            proxy[:addr], proxy[:port], proxy[:user], proxy[:pass])
+    end
+
+    http.use_ssl = true
+    http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+    http.open_timeout = 30
+    return http
+  end # create_secure_http
+
+end # class LogStash::Outputs::OMS
 
 class CaseSensitiveString < String
     def downcase

--- a/logstash-output-OMS.gemspec
+++ b/logstash-output-OMS.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name = "logstash-output-OMS"
-  s.version = "0.1.0"
-  s.licenses = ["Apache License (2.0)"]
+  s.version = "0.1.1"
+  s.licenses = ["Apache-2.0"]
   s.summary = "This output lets you send events to a workspace at Microsoft Operations Management Suite (OMS) based on Logstash events."
   s.description = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"
   s.authors = ["Elastic"]

--- a/logstash-output-OMS.gemspec
+++ b/logstash-output-OMS.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "output" }
 
   # Gem dependencies
-  s.add_runtime_dependency "logstash-core", ">= 1.4.0", "< 2.0.0"
-  s.add_runtime_dependency "logstash-codec-plain"
-  s.add_development_dependency "logstash-devutils"
+  s.add_runtime_dependency "logstash-core", ">= 1.4.0", "< 3.0.0"
+  s.add_runtime_dependency "logstash-codec-plain", '~> 0'
+  s.add_development_dependency "logstash-devutils", '~> 0'
 end

--- a/logstash-output-OMS.gemspec
+++ b/logstash-output-OMS.gemspec
@@ -19,6 +19,5 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core", ">= 1.4.0", "< 3.0.0"
-  s.add_runtime_dependency "logstash-codec-plain", '~> 0'
   s.add_development_dependency "logstash-devutils", '~> 0'
 end

--- a/spec/outputs/oms_spec.rb
+++ b/spec/outputs/oms_spec.rb
@@ -4,9 +4,9 @@ require "logstash/outputs/example"
 require "logstash/codecs/plain"
 require "logstash/event"
 
-describe LogStash::Outputs::Example do
+describe LogStash::Outputs::OMS do
   let(:sample_event) { LogStash::Event.new }
-  let(:output) { LogStash::Outputs::Example.new }
+  let(:output) { LogStash::Outputs::OMS.new }
 
   before do
     output.register


### PR DESCRIPTION
Added support to get sharedKey configuration option from file, specifying a file where the key is on plain text. The new config option is "oms_creds_file", expecting a path

It is not possible to have both "oms_creds_file" and "sharedKey" on the logstash configuration file

Also added support for logstash 1.X and 2.X

Tested in logstash 1.5.4 and 2.3.2
